### PR TITLE
:bug: fix bug before first advent

### DIFF
--- a/adventskranz
+++ b/adventskranz
@@ -58,7 +58,7 @@ candlesum(){
     echo 2
   elif [ $today -lt $(date --date $year-$secondad_month-$secondad_day +%s) ] && [ $today -ge $(date --date $year-$firstad_month-$firstad_day +%s) ]; then
     echo 1
-  elif [ $today -lt $(date --date $year-$firstad_month-$secondad_day +%s) ]; then
+  elif [ $today -lt $(date --date $year-$firstad_month-$firstad_day +%s) ]; then
     echo 0
   fi
 }


### PR DESCRIPTION
The detection of the necessary number of candles failed before the first advent cause of a typo :christmas_tree: 