### PR TITLE
Make script POSIX-compliant

### DIFF
--- a/adventskranz
+++ b/adventskranz
@@ -83,7 +83,7 @@ while [ -n "$1" ]; do
     if [ "$1" = "-c" ] || [ "$1" = "--candle" ]; then
         shift
         CANDLE_NUM=$1
-        if [[ $CANDLE_NUM = -* ]]; then
+        if echo $CANDLE_NUM | grep -qe '-.*'; then
             echo "no time travelling, honey ;)"
             exit 1
         fi

--- a/adventskranz
+++ b/adventskranz
@@ -35,7 +35,7 @@ candlesum(){
   
   i=0
   while [ $(date +%u --date "$year-12-24 -$i days") != "7" ]; do
-    let "i=i+1"
+    i=$(($i+1))
     fourthad_day=$(date +%d --date "$year-12-24 -$i days")
   done
   


### PR DESCRIPTION
I noticed that when executing the script via `./adventskranz` instead of sourcing it in the `.bashrc` or issuing `bash adventskranz`, it returns a lot of error messages:
```bash
$ ./adventskranz
./adventskranz: 38: ./adventskranz: let: not found
./adventskranz: 38: ./adventskranz: let: not found
./adventskranz: 38: ./adventskranz: let: not found
./adventskranz: 38: ./adventskranz: let: not found
```

This is due to the shebang being `!#/bin/sh`, i.e., a POSIX-compliant shell, in which `let` and `[[`/`]]` are not usable.

This PR replaces those two not POSIX-compliant lines by its POSIX-compliant counterparts and, therefore, makes it possible to execute the script in every POSIX-shell.

Another solution would be to change the shebang to `/bin/bash` instead without altering the code. However, I thought that making the script more general is to be preferred.